### PR TITLE
Add info about total lines from backup file in content:db:backup

### DIFF
--- a/content/z.yml
+++ b/content/z.yml
@@ -156,8 +156,16 @@ tasks:
             target_env: ?
         set:
             _backup_file: sprintf("content-%s-%s.tar.gz", target_env, now)
+            _min_lines: 20
         flags:
             local: false
         do:
             - $(z.cmd) content:db:pull $(target_env) --stdout $(local ? "--local") --no-drop | gzip -c > $(_backup_file)
             - echo "Backup <comment>$(_backup_file)</comment> created from <info>$(target_env)</info>"
+            - |
+                if (( "$$(zcat $(_backup_file) | wc -l )" <= $(_min_lines) )); then
+                    echo "<error>The file contains only a few lines. File content is shown below so you can check for errors:</error>"
+                    zcat $(_backup_file)
+                else
+                    printf "Backup contains <comment>" && zcat $(_backup_file) | wc -l | tr -d '\n' && echo "</comment> lines"
+                fi


### PR DESCRIPTION
Deze PR is een aanvulling voor het z commando `z content:db:backup`.

Uitleg:
- `zcat $(_backup_file)`: specifiek commando om het `tar.gz`-bestand uit te lezen
- `wc -l`: telt het aantal regels
- `tr -d '\n'`: dit verwijdert de newline, omdat ik nog meer tekst op dezelfde regel wilde plaatsen

- Wanneer het script het backupbestand uitleest en het aantal regels is kleiner of gelijk aan 20, dan toont het de volledige inhoud van de backup.
![image](https://user-images.githubusercontent.com/57255942/71884528-cfa75100-3138-11ea-8602-deb944ed9c46.png)

- Als er meer dan 20 regels in het bestand zitten, kunnen we ervan uitgaan dat het maken van de backup goed is verlopen en het script toont daarna het totaal aantal regels:
![image](https://user-images.githubusercontent.com/57255942/71884451-aedefb80-3138-11ea-91aa-ccf0ff48c761.png)

