### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,5 +12,4 @@ The following tasks are available:
 * Rsync'ing files (`content:download-files` and `content:upload-files`)
 
 # Maintainers
-* Philip Bergman <philip@zicht.nl>
-* Michael Roterman <michael@zicht.nl>
+* Jochem Klaver <jochem@zicht.nl>

--- a/content/z.yml
+++ b/content/z.yml
@@ -155,7 +155,7 @@ tasks:
         args:
             target_env: ?
         set:
-            _backup_file: sprintf("content-%s-%s.tar.gz", target_env, now)
+            _backup_file: sprintf("content-%s-%s.sql.gz", target_env, now)
             _min_lines: 20
         flags:
             local: false


### PR DESCRIPTION
### Fixed backup files extension

Changed from .tar.gz to .sql.gz. It is not a TAR file. Only gzip compression is being applied. The output is being piped to gzip instead of supplying a file. When gunzipping, gzip wil strip .gz to restore the filename.

```bash
$ z content:db:pull development --stdout --local --no-drop | gzip -c > content-development-20210709111821.sql.gz
...
$ gunzip -v content-development-20210709111821.sql.gz
content-development-20210709111821.sql.gz:	 72.3% -- replaced with content-development-20210709111821.sql
```