### PR TITLE
Introduce defaults-extra-file

### DIFF
--- a/content/Plugin.php
+++ b/content/Plugin.php
@@ -63,7 +63,7 @@ class Plugin extends BasePlugin implements PluginTaskListenerInterface
             },
             true
         );
-        
+
          $container->fn(
             ['content', 'fmt', 'path'],
             function(...$parts) {
@@ -77,7 +77,7 @@ class Plugin extends BasePlugin implements PluginTaskListenerInterface
                 return $path;
             }
         );
-        
+
         $container->fn(
             ['content', 'is_local'],
             function (Container $c) {
@@ -110,8 +110,16 @@ class Plugin extends BasePlugin implements PluginTaskListenerInterface
 
                 $isLocal = $c->resolve('content.is_local')[0];
 
+                $ret = null;
                 if ($isLocal($c) && is_file(sprintf('./etc/mysql/.%s.cnf', $c->resolve('target_env')))) {
-                    return sprintf('--defaults-file=./etc/mysql/.%s.cnf', $c->resolve('target_env'));
+                    $ret = sprintf('--defaults-file=./etc/mysql/.%s.cnf', $c->resolve('target_env'));
+                }
+                if ($isLocal($c) && is_file($c->resolve('defaults_extra_local'))) {
+                    $ret .= sprintf(' --defaults-extra-file=%s', $c->resolve('defaults_extra_local'));
+                }
+
+                if ($ret) {
+                    return $ret;
                 }
 
                 return false;

--- a/content/z.yml
+++ b/content/z.yml
@@ -109,6 +109,7 @@ tasks:
             where: false
             database: envs.local.db
             defaults_local: if_exist("./etc/mysql/.local.cnf")
+            defaults_extra_local: if_exist("./etc/mysql/.my.cnf")
             defaults_remote: false
         args:
             target_env: ?


### PR DESCRIPTION
Deze kan gebruikt worden om dit op te lossen: https://github.com/zicht/cookiecutter-symfony-cms/blob/release/4.x/%7B%7Bcookiecutter.domain_name%7D%7D/etc/mysql/.testing.cnf#L6

* Toevoegen van een .my.cnf.dist in de `etc/mysql` map + een gitignore op .my.cnf
* In deze .dist zitten dan de 2 regels voor `mysqldump` (niet uitgecommentaard)

Om dit te gebruiken zet je de .dist om in een echte .my.cnf